### PR TITLE
Allow the bundle to be built froma multi-release JAR.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,12 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.5.0</version>
+          <configuration>
+            <instructions>
+              <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
+            </instructions>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Note that classes under META-INF/versions will not be used in the Import-Package
calculation, nor will they be visible in an OSGi runtime.